### PR TITLE
feat: add widevine license helpers

### DIFF
--- a/entry/src/main/ets/license/License.ets
+++ b/entry/src/main/ets/license/License.ets
@@ -1,0 +1,70 @@
+import crypto from '@ohos/security.crypto';
+import http from '@ohos/net.http';
+import { LicenseRequest, LicenseRequest_LicenseType, SignedMessage, SignedMessage_MessageType } from '../../../proto/license_protocol_pb';
+
+export interface ContentDecryptionModule {
+  privateKey: Uint8Array;
+  identifierBlob: Uint8Array;
+}
+
+/**
+ * Minimal Widevine license helper implemented with ArkTS APIs.
+ */
+export class License {
+  private devicePrivateKey: crypto.PriKey;
+  private identifierBlob: Uint8Array;
+  private pssh: Uint8Array;
+  private rawLicenseRequest: Uint8Array | null = null;
+
+  constructor(cdm: ContentDecryptionModule, pssh: Uint8Array) {
+    this.devicePrivateKey = crypto.importPriKey(cdm.privateKey);
+    this.identifierBlob = cdm.identifierBlob;
+    this.pssh = pssh;
+  }
+
+  /**
+   * Build a SignedMessage wrapping a LicenseRequest and sign it with the device
+   * private key.
+   */
+  async createLicenseRequest(
+    licenseType: LicenseRequest_LicenseType = LicenseRequest_LicenseType.STREAMING
+  ): Promise<Uint8Array> {
+    const request = LicenseRequest.create({
+      pssh: this.pssh,
+      clientId: this.identifierBlob,
+      type: licenseType
+    });
+    const payload = LicenseRequest.encode(request).finish();
+
+    const signer = await crypto.createSign('RSA', { key: this.devicePrivateKey, digest: 'SHA256' });
+    signer.update(payload);
+    const signature = await signer.sign();
+
+    const message = SignedMessage.create({
+      type: SignedMessage_MessageType.LICENSE_REQUEST,
+      msg: payload,
+      signature
+    });
+
+    this.rawLicenseRequest = SignedMessage.encode(message).finish();
+    return this.rawLicenseRequest;
+  }
+
+  /**
+   * Post the prepared license request to the specified server and return the raw
+   * license response.
+   */
+  async post(url: string): Promise<Uint8Array> {
+    if (!this.rawLicenseRequest) {
+      throw new Error('call createLicenseRequest first');
+    }
+    const client = http.createHttp();
+    const res = await client.request(url, {
+      method: http.RequestMethod.POST,
+      extraData: this.rawLicenseRequest.buffer,
+      header: { 'Content-Type': 'application/octet-stream' }
+    });
+    client.destroy();
+    return new Uint8Array(res.result as ArrayBuffer);
+  }
+}

--- a/entry/src/main/ets/utils/Cmac.ets
+++ b/entry/src/main/ets/utils/Cmac.ets
@@ -1,0 +1,22 @@
+import crypto from '@ohos/security.crypto';
+
+/**
+ * AES-CMAC helper used by Widevine license flow.
+ */
+export class AESCMAC {
+  private key: Uint8Array;
+
+  constructor(key: Uint8Array) {
+    this.key = key;
+  }
+
+  /**
+   * Calculate CMAC over the provided data using the supplied key.
+   */
+  async calculate(data: Uint8Array): Promise<Uint8Array> {
+    const symKey = await crypto.createSymKey('AES', this.key);
+    const mac = await crypto.createMac('AES-CMAC', { key: symKey });
+    mac.update(data);
+    return mac.doFinal();
+  }
+}

--- a/proto/license_protocol.proto
+++ b/proto/license_protocol.proto
@@ -1,0 +1,21 @@
+syntax = "proto2";
+
+message LicenseRequest {
+  optional bytes pssh = 2;
+  optional bytes client_id = 3;
+  optional LicenseType type = 4;
+  enum LicenseType {
+    STREAMING = 1;
+    OFFLINE = 2;
+  }
+}
+
+message SignedMessage {
+  enum MessageType {
+    LICENSE_REQUEST = 1;
+    LICENSE = 2;
+  }
+  optional MessageType type = 1;
+  optional bytes msg = 2;
+  optional bytes signature = 3;
+}

--- a/proto/license_protocol_pb.ts
+++ b/proto/license_protocol_pb.ts
@@ -1,0 +1,59 @@
+import { Reader, Writer } from '@ohos/protobufjs/minimal';
+
+export enum LicenseRequest_LicenseType {
+  STREAMING = 1,
+  OFFLINE = 2,
+}
+
+export interface LicenseRequest {
+  pssh?: Uint8Array;
+  clientId?: Uint8Array;
+  type?: LicenseRequest_LicenseType;
+}
+
+export const LicenseRequest = {
+  encode(message: LicenseRequest, writer: Writer = Writer.create()): Writer {
+    if (message.pssh !== undefined) {
+      writer.uint32(18).bytes(message.pssh);
+    }
+    if (message.clientId !== undefined) {
+      writer.uint32(26).bytes(message.clientId);
+    }
+    if (message.type !== undefined) {
+      writer.uint32(32).int32(message.type);
+    }
+    return writer;
+  },
+  create(base?: Partial<LicenseRequest>): LicenseRequest {
+    return { ...base } as LicenseRequest;
+  }
+};
+
+export enum SignedMessage_MessageType {
+  LICENSE_REQUEST = 1,
+  LICENSE = 2,
+}
+
+export interface SignedMessage {
+  type?: SignedMessage_MessageType;
+  msg?: Uint8Array;
+  signature?: Uint8Array;
+}
+
+export const SignedMessage = {
+  encode(message: SignedMessage, writer: Writer = Writer.create()): Writer {
+    if (message.type !== undefined) {
+      writer.uint32(8).int32(message.type);
+    }
+    if (message.msg !== undefined) {
+      writer.uint32(18).bytes(message.msg);
+    }
+    if (message.signature !== undefined) {
+      writer.uint32(26).bytes(message.signature);
+    }
+    return writer;
+  },
+  create(base?: Partial<SignedMessage>): SignedMessage {
+    return { ...base } as SignedMessage;
+  }
+};


### PR DESCRIPTION
## Summary
- add AES-CMAC helper using HarmonyOS crypto APIs
- define Widevine license protocol messages
- implement minimal ArkTS license helper to build and send license requests

## Testing
- `npm test` *(fails: Could not read package.json)*
- `ohpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac22331b808331a2311364bbde61e6